### PR TITLE
Opção rudimentar para automação

### DIFF
--- a/automate_commit.sh
+++ b/automate_commit.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Compiling and commiting. This script is designed to be used inside a crontab.
+
+today=$(date +'%Y-%m-%d')
+commit_message="Updating document for ${today}"
+
+Rscript -e "rmarkdown::render('./index.Rmd')"
+
+git add index.html
+
+git commit -m "$commit_message"
+
+git push origin master


### PR DESCRIPTION
Mudanças:
  * Adição de script `automate_commit.sh`.

Apesar de existirem serviços de autocommit pro git, pra uma operação simples assim, uma opção rudimentar mas que funciona é inserir o script num crontab da seguinte forma:

`00 17 * * * cd /caminho/pro/repo && ./automate_commit.sh`
